### PR TITLE
Bump versions for slbeta3 in master branch 

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,7 +23,7 @@ For more information, go to the module(s).
 
         > **Note:** Set the JAVA_HOME environment variable to the path name of the directory in which you installed JDK.
 
-2. Download and install [Ballerina Swan Lake Beta2](https://ballerina.io/). 
+2. Download and install [Ballerina Swan Lake Beta3](https://ballerina.io/). 
 
 ## Building the Source
 Execute the commands below to build from the source after installing Ballerina Swan Lake Beta2 version:

--- a/github/Dependencies.toml
+++ b/github/Dependencies.toml
@@ -1,26 +1,24 @@
 [[dependency]]
 org = "ballerina"
 name = "http"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "regex"
-version = "0.7.0-beta.2"
+version = "0.7.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "log"
-version = "1.1.0-beta.2"
+version = "1.1.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "websub"
-version = "1.2.0-beta.2"
+version = "1.2.0-beta.3"
 
 [[dependency]]
 org = "ballerina"
 name = "os"
-version = "0.8.0-beta.2"
-
-
+version = "0.8.0-beta.3"

--- a/github/Package.md
+++ b/github/Package.md
@@ -6,7 +6,7 @@ The `ballerinax/github` is a [Ballerina](https://ballerina.io/) connector for Gi
 ### Compatibility
 |                                                                                    | Version               |
 |------------------------------------------------------------------------------------|-----------------------|
-| Ballerina Language                                                                 | Swan Lake Beta2       |
+| Ballerina Language                                                                 | Swan Lake Beta3       |
 | [Github API](https://docs.github.com/en/graphql)                                   | v4.0                  |
 
 ## Report Issues


### PR DESCRIPTION
## Purpose
- Bump version to slbeta3 in Dependencies.toml, README.md and Package.md

## Security checks
 - Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? yes
 - Ran FindSecurityBugs plugin and verified report? no
 - Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? yes

## Test environment
JDK 11
Ballerina SLBeta3-SNAPSHOT
