### PR TITLE
Bump version to 0.99.21

### DIFF
--- a/github/Ballerina.toml
+++ b/github/Ballerina.toml
@@ -1,7 +1,7 @@
 [package]
 org = "ballerinax"
 name = "github"
-version = "0.99.20"
+version = "0.99.21"
 export= ["github", "github.webhook"]
 authors = ["Ballerina"]
 keywords = ["github", "endpoint", "API"]
@@ -12,7 +12,7 @@ license = ["Apache-2.0"]
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-0.99.14.jar"
+path = "../java-wrapper/build/libs/java-wrapper-0.99.21.jar"
 groupId = "io.ballerinax.webhook"
 artifactId = "java-wrapper"
-version = "0.99.14"
+version = "0.99.21"

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=io.ballerinax.webhook
-version=0.99.14
+version=0.99.21
 ballerinaLangVersion=2.0.0-beta.3


### PR DESCRIPTION
# Description
Bump the version to `0.99.21` in Ballerina.toml and other java components

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
