### PR TITLE
prepare connector for 2201.0.0 release

### DIFF
--- a/github/Ballerina.toml
+++ b/github/Ballerina.toml
@@ -1,8 +1,8 @@
 [package]
-distribution = "slbeta6"
+distribution = "2201.0.0"
 org = "ballerinax"
 name = "github"
-version = "3.0.1"
+version = "3.1.0"
 export= ["github", "github.webhook"]
 authors = ["Ballerina"]
 keywords = ["IT Operations/Source Control", "Cost/Freemium"]
@@ -14,7 +14,7 @@ license = ["Apache-2.0"]
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-3.0.1.jar"
+path = "../java-wrapper/build/libs/java-wrapper-3.1.0.jar"
 groupId = "io.ballerinax.webhook"
 artifactId = "java-wrapper"
-version = "3.0.1"
+version = "3.1.0"

--- a/github/Dependencies.toml
+++ b/github/Dependencies.toml
@@ -217,7 +217,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.0"
+version = "1.0.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -317,7 +317,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "github"
-version = "3.0.1"
+version = "3.1.0"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/github/Package.md
+++ b/github/Package.md
@@ -6,7 +6,7 @@ The `ballerinax/github` is a [Ballerina](https://ballerina.io/) connector for Gi
 ### Compatibility
 |                                                                                    | Version               |
 |------------------------------------------------------------------------------------|-----------------------|
-| Ballerina Language                                                                 | Swan Lake Beta6       |
+| Ballerina Language                                                                 | Swan Lake 2201.0.0    |
 | [Github API](https://docs.github.com/en/graphql)                                   | v4.0                  |
 
 ## Report Issues

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=io.ballerinax.webhook
-version=3.0.1
+version=3.1.0
 ballerinaLangVersion=2201.0.0-20220124-155500-c100a354


### PR DESCRIPTION
# Description
https://github.com/ballerina-platform/ballerina-extended-library/issues/265
- Bump version to `3.1.0`
- Update Ballerina version to `2201.0.0` in Package.md 
- Regenerate Dependencies.toml with `2201.0.0`
- Add `distribution = "2201.0.0"` in Ballerina.toml

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
