### PR TITLE
Fix multi words query in search operation

### DIFF
--- a/github/Ballerina.toml
+++ b/github/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.0.0"
 org = "ballerinax"
 name = "github"
-version = "3.2.0"
+version = "3.2.1"
 export= ["github", "github.webhook"]
 authors = ["Ballerina"]
 keywords = ["IT Operations/Source Control", "Cost/Freemium"]
@@ -14,7 +14,7 @@ license = ["Apache-2.0"]
 observabilityIncluded = true
 
 [[platform.java11.dependency]]
-path = "../java-wrapper/build/libs/java-wrapper-3.2.0.jar"
+path = "../java-wrapper/build/libs/java-wrapper-3.2.1.jar"
 groupId = "io.ballerinax.webhook"
 artifactId = "java-wrapper"
-version = "3.2.0"
+version = "3.2.1"

--- a/github/Dependencies.toml
+++ b/github/Dependencies.toml
@@ -318,7 +318,7 @@ modules = [
 [[package]]
 org = "ballerinax"
 name = "github"
-version = "3.2.0"
+version = "3.2.1"
 dependencies = [
 	{org = "ballerina", name = "http"},
 	{org = "ballerina", name = "jballerina.java"},

--- a/github/tests/test.bal
+++ b/github/tests/test.bal
@@ -718,9 +718,23 @@ function testGetOrganizationMembersList() returns @tainted Error? {
 }
 function testSearch() returns @tainted Error? {
     log:printInfo("githubClient -> search()");
-    SearchResult response = check githubClient-> search("connector-",SEARCH_TYPE_USER, 10);
+    SearchResult response = check githubClient-> search("connector-", SEARCH_TYPE_USER, 10);
     var result = response.results;
     test:assertTrue(result is User[]);    
+}
+
+@test:Config {
+    groups: ["network-calls"],
+    enable: true
+}
+function testSearchMultiWordsString() returns @tainted Error? {
+    log:printInfo("githubClient -> testSearchMultiWordsString()");
+ 
+    string query = string `repo:ballerina-platform/ballerina-extended-library is:issue is:open label:
+    "Type/New Feature"`;
+    SearchResult response = check githubClient-> search(query, SEARCH_TYPE_ISSUE, 1);
+    Issue[]|User[]|Organization[]|Repository[] result = response.results;
+    test:assertTrue(result is Issue[]);    
 }
 
 @test:Config{

--- a/github/utils.bal
+++ b/github/utils.bal
@@ -509,12 +509,14 @@ isolated function getFormulatedStringQueryForGetUserOwnerId(string userName) ret
 
 isolated function getFormulatedStringQueryForSearch(string searchQuery, SearchType searchType, int perPageCount,
                                                     string? lastPageCursor) returns string {
+    string query = searchQuery.indexOf(string `"`) !is () ? regex:replaceAll(searchQuery, string `"`, string `\\"`) : 
+    searchQuery;
     if lastPageCursor is string {
-        return string `{"variables":{"searchQuery":"${searchQuery}", "searchType": ${searchType.toBalString()},
+        return string `{"variables":{"searchQuery":"${query}", "searchType": ${searchType.toBalString()},
                     "perPageCount":${perPageCount}, "lastPageCursor":"${lastPageCursor}"},"query":"`
                     + string `${SEARCH}"}`;
     } else {
-        return string `{"variables":{"searchQuery":"${searchQuery}", "searchType": ${searchType.toBalString()},
+        return string `{"variables":{"searchQuery":"${query}", "searchType": ${searchType.toBalString()},
                     "perPageCount":${perPageCount}, "lastPageCursor":null},"query":"`
                     + string `${SEARCH}"}`;
     }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,4 +1,4 @@
 org.gradle.caching=true
 group=io.ballerinax.webhook
-version=3.2.0
+version=3.2.1
 ballerinaLangVersion=2201.0.3


### PR DESCRIPTION
# Description
Fix multi words query in search operation.
As per [Github documentation](https://docs.github.com/en/search-github/searching-on-github/searching-issues-and-pull-requests#search-by-label), if there are more than one word in a query key value, the value should be given in `" "`.

Example:
```ballerina
string query= "repo:ballerina-platform/ballerina-extended-library is:issue label:\"Type/New Feature\"";
```

Fixes
https://github.com/wso2-enterprise/choreo/issues/13147

One line release note: 
- Support multi words value for query value in search operation

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [x] Unit test

**Test Configuration**:
* Ballerina Version: 2201.0.3
* Operating System:Ubuntu
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
