### PR TITLE
Add the functionality to get the repository content

### DIFF
--- a/github/Dependencies.toml
+++ b/github/Dependencies.toml
@@ -9,7 +9,7 @@ dependencies-toml-version = "2"
 [[package]]
 org = "ballerina"
 name = "auth"
-version = "2.2.1"
+version = "2.3.1"
 dependencies = [
 	{org = "ballerina", name = "crypto"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -22,7 +22,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "cache"
-version = "3.2.1"
+version = "3.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "task"},
@@ -32,7 +32,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "crypto"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -41,7 +41,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "file"
-version = "1.2.2"
+version = "1.3.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -54,7 +54,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -84,7 +84,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.2.1"
+version = "1.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -98,7 +98,7 @@ version = "0.0.0"
 [[package]]
 org = "ballerina"
 name = "jwt"
-version = "2.2.1"
+version = "2.3.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -176,7 +176,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "log"
-version = "2.2.1"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -190,7 +190,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.2.2"
+version = "2.3.0"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -200,7 +200,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "oauth2"
-version = "2.2.1"
+version = "2.3.1"
 dependencies = [
 	{org = "ballerina", name = "cache"},
 	{org = "ballerina", name = "crypto"},
@@ -212,7 +212,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "observe"
-version = "1.0.4"
+version = "1.0.5"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -220,7 +220,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "os"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -231,9 +231,10 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "regex"
-version = "1.2.1"
+version = "1.3.0"
 dependencies = [
-	{org = "ballerina", name = "jballerina.java"}
+	{org = "ballerina", name = "jballerina.java"},
+	{org = "ballerina", name = "lang.string"}
 ]
 modules = [
 	{org = "ballerina", packageName = "regex", moduleName = "regex"}
@@ -242,7 +243,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"}
@@ -263,7 +264,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -271,7 +272,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.2.1"
+version = "2.2.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]

--- a/github/endpoints.bal
+++ b/github/endpoints.bal
@@ -108,6 +108,19 @@ public isolated client class Client {
         return new stream<Repository, Error?>(repositoryStream);
     }
 
+    # Get repository content
+    #
+    # + owner - Repository owner name
+    # + repositoryName - GitHub repository name
+    # + expression - The expression in the form `<branch_name>:<path_to_directory>` 
+    #   Eg: master:.github path will list the contents on .github folder in the master branch
+    #
+    # + return - `github:File[]` record if successful else `github:Error`
+    @display {label: "Get repository content"}
+    remote isolated function getRepositoryContent(string owner, string repositoryName, string expression) returns File[]|Error {
+        return getRepositoryContent(owner, repositoryName, expression, self.authToken, self.githubGraphQlClient);
+    }
+
     # Get collaborators
     #
     # + owner - Repository owner name

--- a/github/queries.bal
+++ b/github/queries.bal
@@ -273,6 +273,16 @@ final string SEARCH_COUNT = "codeCount,\n" +
                             "userCount,\n" +
                             "wikiCount,\n";
 
+final string REPOSITORY_ENTRY_FIELDS = "name,\n"+
+                                        "type,\n" +
+                                        "object {,\n" +
+                                        "   ... on Blob {" +
+                                        "           byteSize,\n" +
+                                        "           text,\n" +
+                                        "           isBinary,\n" +
+                                        "       }\n" +
+                                        "}";
+
 final string GET_AUTHENTICATED_USER_QUERY = "query { \n" +
                                             "    viewer {              \n" +
                                                 USER +
@@ -670,3 +680,17 @@ final string SEARCH = "query ($searchQuery: String!, $searchType: SearchType!, $
                         "       }\n" +
                         "   }\n" +
                         "}";
+
+
+// Repository content
+final string GET_REPOSITORY_CONTENT = "query($owner:String!, $name:String!, $expr: String!){\n" +
+                                "       repository(owner: $owner, name: $name){\n" +
+                                "               object(expression: $expr){\n" +
+                                "                       ... on Tree {\n" +
+                                "                               entries {\n"+
+                                                                        REPOSITORY_ENTRY_FIELDS +
+                                "                               }\n" +
+                                "                       }\n" +
+                                "               }\n" +
+                                "       }\n" +
+                                "}";

--- a/github/tests/test.bal
+++ b/github/tests/test.bal
@@ -636,3 +636,12 @@ function testGetLanguagesFromRepository() returns error? {
         test:assertFail("Language list is empty");
     }
 }
+
+@test:Config{
+    enable: true
+}
+function testGetRepositoryContent() returns error? {
+    log:printInfo("githubClient -> testGetRepositoryContent()");
+    File[] response = check githubClient->getRepositoryContent(testUsername, testUserRepositoryName, "HEAD:");
+    test:assertTrue(response.length() > 0, "Failed to get file list");
+}

--- a/github/types.bal
+++ b/github/types.bal
@@ -1636,3 +1636,25 @@ public type GraphQLClientSourceLocation record {
     int line?;
     int column?;
 };
+
+# The information and content of the file
+#
+# + name - File/Folder name 
+# + 'type - Type of the object  
+# + 'object - File content. For folders this object will be empty
+public type File record {
+    string name;
+    string 'type;
+    FileContent 'object;
+};
+
+# File content
+#
+# + byteSize - Byte size of the file  
+# + text - The text respresentation of contents inside the file  
+# + isBinary - If the file content is binary
+public type FileContent record {
+    int byteSize?;
+    string text?;
+    boolean isBinary?;
+};

--- a/github/utils.bal
+++ b/github/utils.bal
@@ -80,6 +80,10 @@ isolated function getFormulatedStringQueryForGetRepository(string username, stri
     return string `{"variables":{"owner":"${username}", "name":"${repositoryName}"},"query":"${GET_REPOSIOTRY}"}`;
 }
 
+isolated function getFormulatedStringQueryForGetRepositoryContent(string username, string repositoryName, string expression) returns string {
+    return string `{"variables":{"owner":"${username}", "name":"${repositoryName}", "expr": "${expression}"},"query":"${GET_REPOSITORY_CONTENT}"}`;
+}
+
 isolated function getFormulatedStringQueryForGetRepositoryList(int perPageCount, boolean isOrganization,
                                                                 string? owner, string? lastPageCursor = ())
                                                                 returns string {


### PR DESCRIPTION
# Description
Include the new functionality to the GitHub connector to retrieve the repository content.

Fixes: https://github.com/ballerina-platform/ballerina-extended-library/issues/352
Fixes: https://github.com/ballerina-platform/ballerina-extended-library/issues/439

One line release note: 
- Add functionality to get the repository content according to the client request 

## Type of change

Please delete options that are not relevant.
- [x] New feature (non-breaking change which adds functionality)

# How Has This Been Tested?
Added a new test case `testGetRepositoryContent`

**Test Configuration**:
* Ballerina Version: 2201.1.0
* Operating System: Ubuntu 20.04
* Java SDK: 11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
