### PR TITLE
Fix the bug in the github:File record type

### DIFF
--- a/github/types.bal
+++ b/github/types.bal
@@ -1657,7 +1657,7 @@ public type GraphQLClientSourceLocation record {
 public type File record {
     string name;
     string 'type;
-    FileContent 'object;
+    FileContent? 'object;
 };
 
 # File content
@@ -1667,6 +1667,6 @@ public type File record {
 # + isBinary - If the file content is binary
 public type FileContent record {
     int byteSize?;
-    string text?;
-    boolean isBinary?;
+    string? text?;
+    boolean? isBinary?;
 };


### PR DESCRIPTION
# Description

The data binding fails in some scenarios where we obtain the repo content. This happens due to having nullable fields in the response which are marked as non-null. Fixed it by following the GraphQL SDL

Reference
https://docs.github.com/en/graphql/reference/objects#treeentry

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

**Test Configuration**:
* Ballerina Version: 2201.1.0
* Operating System: Ubuntu 20.04
* Java SDK: 11

# Checklist:
### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
