### PR TITLE
Add the functionality to provide the number of reviews to retrieve

### DIFF
--- a/github/endpoints.bal
+++ b/github/endpoints.bal
@@ -525,19 +525,22 @@ public isolated client class Client {
     # + perPageCountForLabels - Number of labels in each issue to be returned. Defaulted to 10.
     # + perPageCountForAssignees - Number of assinees for each pull request to be returned. Defaulted to 10.
     # + perPageCountForRelatedIssues - Number of related issues for each pull request to be returned. Defaulted to 10.
+    # + perPageCountForPRReviews - Number of reviews for each pull request to be returned. Defaulted to 10.
     # + lastPageCursor - Next page curser
     #
     # + return - `github:SearchResult` record if successful or else `github:Error`
     @display {label: "Search"}
     remote isolated function search(string searchQuery, SearchType searchType, int perPageCount,
                                     int perPageCountForLabels = 10, int perPageCountForAssignees = 10,
-                                    int perPageCountForRelatedIssues = 10, string? lastPageCursor = ())
+                                    int perPageCountForRelatedIssues = 10, int perPageCountForPRReviews = 10, 
+                                    string? lastPageCursor = ())
                                     returns SearchResult|Error {
         SearchType querySearchType = searchType is SEARCH_TYPE_ORGANIZATION ? SEARCH_TYPE_USER :
                                     searchType is SEARCH_TYPE_PULL_REQUEST ? SEARCH_TYPE_ISSUE : searchType;
         string stringQuery = getFormulatedStringQueryForSearch(searchQuery, querySearchType, perPageCount,
                                                                 perPageCountForLabels, perPageCountForAssignees,
-                                                                perPageCountForRelatedIssues, lastPageCursor);
+                                                                perPageCountForRelatedIssues, perPageCountForPRReviews, 
+                                                                lastPageCursor);
         map<json>|Error graphQlData = getGraphQlData(self.githubGraphQlClient, self.authToken, stringQuery);
 
         if graphQlData is map<json> {

--- a/github/queries.bal
+++ b/github/queries.bal
@@ -280,7 +280,7 @@ final string SEARCH_PULL_REQUEST__FIELDS = PULL_REQUEST_FIELDS +
                                         CLOSING_ISSUE_REFERENCES +
                                         PULL_REQUEST_REVIEWS;
 
-final string PULL_REQUEST_REVIEWS =     "        reviews(first: 10) {\n" +
+final string PULL_REQUEST_REVIEWS =     "        reviews(first: $perPageCountForPRReviews) {\n" +
                                         "               nodes {,\n" +
                                         "               author {,\n" +
                                         "                       login,\n" +
@@ -718,7 +718,7 @@ final string GET_USER_OWNER_ID = "query($userName: String!){\n" +
                                 "}";
 
 final string SEARCH = "query ($searchQuery: String!, $searchType: SearchType!, $perPageCount: Int, $lastPageCursor: String, $perPageCountForLabels: Int," +
-                      "$perPageCountForAssignees: Int, $perPageCountForRelatedIssues: Int) {\n" +
+                      "$perPageCountForAssignees: Int, $perPageCountForRelatedIssues: Int, $perPageCountForPRReviews: Int) {\n" +
                         "   search(query: $searchQuery, type: $searchType, first: $perPageCount, after: $lastPageCursor) {\n" +
                                 SEARCH_COUNT +
                                 PAGE_INFO +

--- a/github/tests/test.bal
+++ b/github/tests/test.bal
@@ -699,6 +699,29 @@ function testSearchPullRequestWithRelatedIssues() returns error? {
     groups: ["network-calls"],
     enable: true
 }
+function testSearchPullRequestWithReviews() returns error? {
+    log:printInfo("githubClient -> testSearchPullRequestWithReviews()");
+
+    string query = string `repo:ballerina-platform/module-ballerinax-github is:pr is:closed review:approved author:sachinira`;
+    SearchResult response = check githubClient->search(query, SEARCH_TYPE_PULL_REQUEST, 5, perPageCountForPRReviews = 1);
+    Issue[]|User[]|Organization[]|Repository[]|PullRequest[] result = response.results;
+
+    if result is PullRequest[] {
+        foreach PullRequest item in result {
+            PullRequestReview[]? pullRequestReviews = item.pullRequestReviews;
+            if pullRequestReviews is PullRequestReview[] {
+                if pullRequestReviews.length() > 0 {
+                    test:assertTrue(pullRequestReviews.length() == 1);
+                }
+            }
+        }
+    }
+}
+
+@test:Config {
+    groups: ["network-calls"],
+    enable: true
+}
 function testSearchUser() returns error? {
     log:printInfo("githubClient -> testSearchUser()");
 

--- a/github/utils.bal
+++ b/github/utils.bal
@@ -513,7 +513,8 @@ isolated function getFormulatedStringQueryForGetUserOwnerId(string userName) ret
 
 isolated function getFormulatedStringQueryForSearch(string searchQuery, SearchType searchType, int perPageCount, 
                                                     int perPageCountForLabels, int perPageCountForAssignees, 
-                                                    int perPageCountForRelatedIssues, string? lastPageCursor) returns string {
+                                                    int perPageCountForRelatedIssues, int perPageCountForPRReviews,
+                                                    string? lastPageCursor) returns string {
     string query = searchQuery.indexOf(string `"`) !is () ? regex:replaceAll(searchQuery, string `"`, string `\"`) : 
     searchQuery;
     if lastPageCursor is string {
@@ -521,13 +522,15 @@ isolated function getFormulatedStringQueryForSearch(string searchQuery, SearchTy
                     "perPageCount":${perPageCount}, "perPageCountForLabels":${perPageCountForLabels}, 
                     "perPageCountForAssignees":${perPageCountForAssignees}, 
                     "perPageCountForRelatedIssues":${perPageCountForRelatedIssues}, 
+                    "perPageCountForPRReviews":${perPageCountForPRReviews},
                     "lastPageCursor":"${lastPageCursor}"},"query":"`+ string `${SEARCH}"}`;
     } else {
         return string `{"variables":{"searchQuery":"${query}", "searchType": ${searchType.toBalString()},
                     "perPageCount":${perPageCount}, "perPageCountForLabels":${perPageCountForLabels}, 
                     "perPageCountForAssignees":${perPageCountForAssignees}, 
-                    "perPageCountForRelatedIssues":${perPageCountForRelatedIssues}, "lastPageCursor":null},"query":"`
-                    + string `${SEARCH}"}`;
+                    "perPageCountForRelatedIssues":${perPageCountForRelatedIssues}, 
+                    "perPageCountForPRReviews":${perPageCountForPRReviews},
+                    "lastPageCursor":null},"query":"`+ string `${SEARCH}"}`;
     }
 }
 


### PR DESCRIPTION
# Description

Add the functionality provide the number of reviews to retrieve for a pull request in the pull request search functionality.

One line release note: 
- Add the functionality to provide the number of reviews

## Type of change
- [x] New feature (non-breaking change which adds functionality)


# How Has This Been Tested?
Added a test case
- testSearchPullRequestWithReviews

**Test Configuration**:
* Ballerina Version: 2201.1.0
* Operating System: Ubuntu 20.04
* Java SDK:  11

# Checklist:

### Security checks
 - [x] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [x] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
