### PR TITLE
Fix GitHub Client Error when nodes in ProjectListPayload contains null values.

### DIFF
--- a/github/projects.bal
+++ b/github/projects.bal
@@ -30,10 +30,12 @@ isolated function getOrganizationProjectList(string organizationName, ProjectSta
             if (projects is map<json>) {
                 ProjectListPayload|error projectListResponse = projects.cloneWithType(ProjectListPayload);
                 if projectListResponse is ProjectListPayload {
+                    Project[] projectsFromResponse = from Project? project in
+                        projectListResponse.nodes where project is Project select project;
                     ProjectList projectList = {
-                        projects: projectListResponse.nodes,
+                        projects: projectsFromResponse,
                         pageInfo: projectListResponse.pageInfo,
-                        totalCount: projectListResponse.totalCount
+                        totalCount: projectsFromResponse.length()
                     };
                     return projectList;
                 }
@@ -166,10 +168,12 @@ isolated function getRepositoryProjectList(string repositoryOwner, string reposi
             if (projects is map<json>) {
                 ProjectListPayload|error projectListResponse = projects.cloneWithType(ProjectListPayload);
                 if projectListResponse is ProjectListPayload {
+                    Project[] projectsFromResponse = from Project? project in
+                        projectListResponse.nodes where project is Project select project;
                     ProjectList projectList = {
-                        projects: projectListResponse.nodes,
+                        projects: projectsFromResponse,
                         pageInfo: projectListResponse.pageInfo,
-                        totalCount: projectListResponse.totalCount
+                        totalCount: projectsFromResponse.length()
                     };
                     return projectList;
                 }
@@ -194,10 +198,12 @@ isolated function getUserProjectList(string username, int perPageCount, string a
             if (projects is map<json>) {
                 ProjectListPayload|error projectListResponse = projects.cloneWithType(ProjectListPayload);
                 if projectListResponse is ProjectListPayload {
+                    Project[] projectsFromResponse = from Project? project in
+                        projectListResponse.nodes where project is Project select project;
                     ProjectList projectList = {
-                        projects: projectListResponse.nodes,
+                        projects: projectsFromResponse,
                         pageInfo: projectListResponse.pageInfo,
-                        totalCount: projectListResponse.totalCount
+                        totalCount: projectsFromResponse.length()
                     };
                     return projectList;
                 }

--- a/github/types.bal
+++ b/github/types.bal
@@ -808,7 +808,7 @@ public type PullRequestReviewList record {
 # + pageInfo - Response pagination info.
 # + totalCount - Total projects count.
 public type ProjectListPayload record {
-    Project[] nodes;
+    Project?[] nodes;
     PageInfo pageInfo;
     int totalCount;
 };


### PR DESCRIPTION
# Description

When the projects for the user are fetched if the nodes array in projects contains any null values, type binding failure happens. This causes to throw GitHub client Error.

Fixes [#501](https://github.com/ballerina-platform/ballerina-extended-library/issues/501)

Related Pull Requests (remove if not relevant)
- Pull request 1
- Pull request 2

One line release note: 
- One line describing the feature/improvement/fix made by this PR 

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected)
- [ ] This change requires a documentation update

# How Has This Been Tested?

Please describe the tests that you ran to verify your changes. Provide instructions so we can reproduce. Please also list any relevant details for your test configuration

- [ ] Test A
- [ ] Test B

**Test Configuration**:
* Ballerina Version:
* Operating System:
* Java SDK: 

# Checklist:

### Security checks
 - [ ] Followed secure coding standards in http://wso2.com/technical-reports/wso2-secure-engineering-guidelines? 
 - [ ] Confirmed that this PR doesn't commit any keys, passwords, tokens, usernames, or other secrets? 
