### PR TITLE
Update GraalVM workflow with new command option

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches-ignore:
+    branches:
       - "automated/dependency_version_update"
       - "automated/dependency_version_update_tmp"
   repository_dispatch:


### PR DESCRIPTION
This PR will rename the command option in the graalVM workflow from --native to --graalvm. Fixes https://github.com/ballerina-platform/ballerina-extended-library/issues/531