### PR TITLE
Replace regex usages with regexp langlib

### DIFF
--- a/ballerina/utils.bal
+++ b/ballerina/utils.bal
@@ -15,7 +15,6 @@
 // under the License.
 
 import ballerina/http;
-import ballerina/regex;
 
 # Construct the request by adding the payload and authorization tokens.
 # + request - HTTP request object
@@ -494,8 +493,7 @@ isolated function getFormulatedStringQueryForSearch(string searchQuery, SearchTy
                                                     int perPageCountForLabels, int perPageCountForAssignees, 
                                                     int perPageCountForRelatedIssues, int perPageCountForPRReviews,
                                                     string? lastPageCursor) returns string {
-    string query = searchQuery.indexOf(string `"`) !is () ? regex:replaceAll(searchQuery, string `"`, string `\"`) : 
-    searchQuery;
+    string query = searchQuery.indexOf(string `"`) !is () ?  re `"`.replaceAll(searchQuery, "\""): searchQuery;
     if lastPageCursor is string {
         return string `{"variables":{"searchQuery":"${query}", "searchType": ${searchType.toBalString()},
                     "perPageCount":${perPageCount}, "perPageCountForLabels":${perPageCountForLabels}, 


### PR DESCRIPTION
# Description
$subject

Due to the `regex` ballerina library is deprecated when  compiling sources which has github library as an import it shows a warning as below.
```
WARNING [extract_data_from_github] ballerina/regex:1.4.3 is deprecated: This library is deprecated and will no longer be maintained or updated. Instead, it is recommended to use the ballerina/lang.regexp.
```

This PR will replace regex usage with `regexp`. 