### PR TITLE
Fix GitHub connector test failure

### DIFF
--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -151,7 +151,12 @@ function testGetMilestones() returns error? {
 // Instead an already created project will be updated and deleted.
 // The reason is Github seems to be adding project async mannger.
 // Sometimes immediate call does not return the project when we try to get the created project.
-@test:Config {}
+// TODO: Re-enable `testCreateUserProject` and `testDeleteProject` if and when the test-user is changed as for this user
+// project creation is disabled due to rate limit.
+// An issue is created to track this: https://github.com/ballerina-platform/ballerina-library/issues/6917
+@test:Config {
+    enable: false
+}
 function testCreateUserProject() returns error? {
     User_projects_body body = {
         name: "Test Project Created by Ballerina GitHub Connector",
@@ -162,7 +167,7 @@ function testCreateUserProject() returns error? {
 }
 
 @test:Config {
-    dependsOn: [testGetMilestone, testCreateUserProject]
+    dependsOn: [testGetMilestone]
 }
 function testCreateIssue() returns error? {
     Repo_issues_body body = {
@@ -462,17 +467,13 @@ function testDeletePullRequestReview() returns error? {
     test:assertTrue(response.id == createdPullRequestReviewIdWithPendingState);
 }
 
-@test:Config {
-    dependsOn: [testCreateUserProject]
-}
+@test:Config {}
 function testGetOrgProjectList() returns error? {
     Project[] response = check github->/orgs/["wso2-enterprise"]/projects();
     test:assertTrue(response[0] is Project);
 }
 
-@test:Config {
-    dependsOn: [testCreateUserProject]
-}
+@test:Config {}
 function testGetLatestUserProject() returns error? {
     Project[] response = check github->/users/[testUsername]/projects();
     if response.length() > 0 {
@@ -497,6 +498,7 @@ function testUpdateProject() returns error? {
 }
 
 @test:Config {
+    enable: false,
     dependsOn: [testUpdateProject, testCreateIssue]
 }
 function testDeleteProject() returns error? {


### PR DESCRIPTION
## Purpose
This PR addresses the recent failures observed in the Daily Build tests.

### Root Cause
The failures stem from the rate limit imposed by the GitHub API on project creation for individual users. The designated test user account has exceeded its allowable limit, leading to these test failures.

### Solution
This PR temporarily disables the creation and deletion of projects within the tests. This measure will prevent further failures due to rate limit breaches. We can consider re-enabling these features if and when the test user account is switched or the rate limit issue is otherwise resolved.

Note: An issue is created to track re-enabling of the disabled tests(https://github.com/ballerina-platform/ballerina-library/issues/6917)