### PR TITLE
Temporarily disable ballerina tests during central publish

### DIFF
--- a/.github/workflows/dev-stg-release.yml
+++ b/.github/workflows/dev-stg-release.yml
@@ -19,3 +19,4 @@ jobs:
     secrets: inherit
     with:
       environment: ${{ github.event.inputs.environment }}
+      additional-publish-flags: "-x :github-ballerina:test"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -15,5 +15,5 @@ jobs:
       package-name: github
       package-org: ballerinax
       additional-build-flags: "-x :github-examples:build"
-      additional-release-flags: "-x :github-examples:build"
-      additional-publish-flags: "-x :github-examples:build"
+      additional-release-flags: "-x :github-examples:build -x :github-ballerina:test"
+      additional-publish-flags: "-x :github-examples:build -x :github-ballerina:test"


### PR DESCRIPTION
## Purpose
$subject as the GitHub token used for testing has expired and needs to be updated in the repository secrets. This update is necessary to remove the blocker for an urgent patch release. The change should be reverted after the patch release is complete.

## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
