### PR TITLE
Removed project related apis and tests, as it is removed in server

### DIFF
--- a/ballerina/tests/test.bal
+++ b/ballerina/tests/test.bal
@@ -41,8 +41,6 @@ string NEW_FEATURE_BRANCH_REF = string `refs/${NEW_FEATURE_BRANCH_HEAD}`;
 
 // Variables to hold intermediate results
 int milestoneNumber = 2;
-int fetchedProjectId = -1;
-int fetchedProjectNumber = -1;
 int createdIssueId = -1;
 int createdIssueNumber = -1;
 int createdIssueCommentId = -1;
@@ -153,26 +151,6 @@ function testGetMilestone() returns error? {
 function testGetMilestones() returns error? {
     Milestone[] response = check github->/repos/[testUsername]/[testUserRepositoryName]/milestones();
     test:assertTrue(response[0] is Milestone);
-}
-
-// ----------NOTE----------
-// The project created by this test case will no be deleted.
-// Instead an already created project will be updated and deleted.
-// The reason is Github seems to be adding project async mannger.
-// Sometimes immediate call does not return the project when we try to get the created project.
-// TODO: Re-enable `testCreateUserProject` and `testDeleteProject` if and when the test-user is changed as for this user
-// project creation is disabled due to rate limit.
-// An issue is created to track this: https://github.com/ballerina-platform/ballerina-library/issues/6917
-@test:Config {
-    enable: false
-}
-function testCreateUserProject() returns error? {
-    UserProjectsBody body = {
-        name: "Test Project Created by Ballerina GitHub Connector",
-        body: "This is the body of the test project"
-    };
-    Project? response = check github->/user/projects.post(body);
-    test:assertEquals(response?.name, "Test Project Created by Ballerina GitHub Connector");
 }
 
 @test:Config {
@@ -498,62 +476,6 @@ function testUpdatePullRequestReview() returns error? {
 function testDeletePullRequestReview() returns error? {
     PullRequestReview response = check github->/repos/[testUsername]/[testUserRepositoryName]/pulls/[createdPullRequestNumber]/reviews/[createdPullRequestReviewIdWithPendingState].delete();
     test:assertTrue(response.id == createdPullRequestReviewIdWithPendingState);
-}
-
-// Enable after fixing this: https://github.com/ballerina-platform/ballerina-library/issues/7777
-@test:Config {enable: false}
-function testGetOrgProjectList() returns error? {
-    Project[] response = check github->/orgs/["wso2-enterprise"]/projects();
-    test:assertTrue(response[0] is Project);
-}
-
-// Enable after fixing this: https://github.com/ballerina-platform/ballerina-library/issues/7777
-@test:Config {enable: false}
-function testGetLatestUserProject() returns error? {
-    Project[] response = check github->/users/[testUsername]/projects();
-    if response.length() > 0 {
-        Project recentProject = response[0];
-        fetchedProjectId = recentProject.id;
-        fetchedProjectNumber = recentProject.number;
-    } else {
-        test:assertFail();
-    }
-}
-
-// Enable after fixing this: https://github.com/ballerina-platform/ballerina-library/issues/7777
-@test:Config {
-    enable: false,
-    dependsOn: [testGetLatestUserProject]
-}
-function testUpdateProject() returns error? {
-    ProjectsprojectIdBody1 body = {
-        name: "Test Project Created by Ballerina GitHub Connector UPDATED"
-    };
-
-    Project? response = check github->/projects/[fetchedProjectId].patch(body);
-    test:assertTrue(response?.number == fetchedProjectNumber);
-}
-
-@test:Config {
-    enable: false,
-    dependsOn: [testUpdateProject, testCreateIssue]
-}
-function testDeleteProject() returns error? {
-    check github->/projects/[fetchedProjectId].delete();
-}
-
-// Enable after fixing this: https://github.com/ballerina-platform/ballerina-library/issues/7777
-@test:Config {enable: false}
-function testGetRepositoryProjectList() returns error? {
-    Project[] response = check github->/repos/[testUsername]/[testUserRepositoryName]/projects();
-    test:assertTrue(response[0] is Project);
-}
-
-// Enable after fixing this: https://github.com/ballerina-platform/ballerina-library/issues/7777
-@test:Config {enable: false}
-function testGetUserProjectList() returns error? {
-    Project[] response = check github->/users/[testUsername]/projects();
-    test:assertTrue(response[0] is Project);
 }
 
 @test:Config {groups: ["mock_tests", "live_tests"]}

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Removed
+- [[#7777](https://github.com/ballerina-platform/ballerina-library/issues/7777)] Removed GitHub Projects (classic) REST API endpoints. GitHub deprecated and removed Projects (classic) in favor of the new Projects experience, which is only available via the GraphQL API. All classic project endpoints now return `404 Not Found`.
+
 ### Breaking Changes
 - [[#8642](https://github.com/ballerina-platform/ballerina-library/issues/8642)] Regenerated the connector from the aligned OpenAPI specification
   - Record field names now use camelCase with `@jsondata:Name` annotations for JSON mapping (e.g., `created_at` -> `createdAt`, `body_html` -> `bodyHtml`)

--- a/docs/spec/Sanitations.md
+++ b/docs/spec/Sanitations.md
@@ -76,6 +76,8 @@ This file documents the modifications applied to enhance the usability of the of
 
 14. Remove the `default: false` from the `allow_forking` field in the `PATCH /repos/{owner}/{repo}` request body (`OwnerrepoBody1`). The GitHub API returns a 422 ("Allow forks can only be changed on org-owned repositories") if `allow_forking` is sent for a personal repository, but the default caused it to always be included in the request. Making it optional (no default) resolves this.
 
+15. Remove all 18 **Projects (classic)** REST API endpoints and their 19 associated component schemas. GitHub deprecated and removed Projects (classic) in May 2024 in favor of the new Projects experience, which is only available via the GraphQL API. All removed endpoints return `404 Not Found`. Removed paths: `/orgs/{org}/projects`, `/user/projects`, `/users/{username}/projects`, `/repos/{owner}/{repo}/projects`, `/projects/{projectId}` and related sub-paths. Removed schemas: `Project`, `ProjectCard`, `ProjectColumn`, `ProjectCollaboratorPermission`, `TeamProject`, and associated request body schemas.
+
 ## OpenAPI cli command
 
 **Important:** The overlay must be applied AFTER `bal openapi align`, not before. The align


### PR DESCRIPTION
## Purpose

This PR updates the Ballerina GitHub connector for the v6.0.0 major release, including a full regeneration from the aligned OpenAPI specification, bug fixes for default value issues causing 422 errors, and removal of the deprecated Projects (classic) REST API.

  Fixes https://github.com/ballerina-platform/ballerina-library/issues/7777
  Fixes https://github.com/ballerina-platform/ballerina-library/issues/8642

## Changes

### Breaking Changes
  - Regenerated the connector from the aligned OpenAPI specification:
    - Record field names now use camelCase with @jsondata:Name annotations for JSON mapping (e.g., created_at → createdAt)
    - Request body type names updated to follow new naming convention
    - Some client resource methods now return optional types

### Removed
  - Removed all 18 GitHub Projects (classic) REST API endpoints and associated types. GitHub deprecated and fully removed Projects (classic) in favour of the new Projects experience (GraphQL-only). All classic project endpoints return 404 Not
  Found.

### Fixed
  - Fixed 422 errors on GET /user/repos caused by type query parameter being sent alongside visibility and affiliation by default — GitHub rejects requests with all three
  - Fixed 422 errors on PATCH /repos/{owner}/{repo} caused by allow_forking always being sent by default — GitHub rejects this field for personal repositories
  - Fixed data binding error when fetching /search/issues due to body field not being nullable

### Tests
  - Added mock service for running tests without external dependencies
  - Made testCreateRepository idempotent with pre-run cleanup

### Type of change

  - Bug fix (non-breaking change which fixes an issue)
  - Breaking change (fix or feature that would cause existing functionality to not work as expected)
  - This change requires a documentation update

  How Has This Been Tested?

  - Mock tests (./gradlew clean test -Pgroups=mock_tests) — 49 passing
  - Live tests against GitHub API (./gradlew clean test -Pgroups=live_tests) — 49 passing


## Examples

## Checklist
- [ ] Linked to an issue
- [ ] Updated the specification
- [ ] Updated the changelog
- [ ] Added tests
- [ ] Checked native-image compatibility
