### PR TITLE
Add refresh token grant

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,35 +11,101 @@ This Ballerina connector is designed to interface with [GitHub's REST API (versi
 
 ## Setup guide
 
-To use the GitHub Connector in Ballerina, you must have a GitHub account and a Personal Access Token (PAT) for authentication. If you already have a GitHub account, you can integrate the connector with your existing account. If not, you can create a new GitHub account by visiting [GitHub's Sign Up page](https://github.com/) and following the registration process. Once you have a GitHub account, you can proceed to create a PAT.
+To use the GitHub Connector in Ballerina you need a GitHub account. If you already have one, you can integrate the connector with your existing account. If not, you can create a new GitHub account by visiting [GitHub's Sign Up page](https://github.com/) and following the registration process.
 
-### Step 1: Access GitHub Settings
+The connector supports two ways of authenticating with the GitHub REST API:
+
+| Authentication | When to use |
+| -------------- | ----------- |
+| **Personal Access Token (PAT)** | A static token bound to your own user account. Simplest option, suited for scripts and single-user automation. Also use this for an OAuth App token, which does not expire. |
+| **OAuth2 refresh token grant** | A GitHub App user access token, which expires after 8 hours and is renewed automatically by the connector. Suited for applications acting on behalf of other users. Requires a GitHub App with expiring user authorization tokens enabled — OAuth Apps do not issue refresh tokens. |
+
+### Option 1: Personal Access Token (PAT)
+
+#### Step 1: Access GitHub Settings
 
 1. Once logged in, click on the profile picture in the top-right corner of the page.
 2. Select **Settings** from the dropdown menu.
 
-### Step 2: Navigate to Developer Settings
+#### Step 2: Navigate to Developer Settings
 
 1. Scroll down in the sidebar on the left side of the settings page.
 2. click on **Developer settings** located near the bottom.
 
-### Step 3: Go to Personal Access Tokens
+#### Step 3: Go to Personal Access Tokens
 
 1. Inside Developer Settings find and click on **Personal access tokens**.
 
     <img src=https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-github/master/docs/setup/resources/1-developer-settings.png alt="GitHub Developer Settings" width="50%">
 
-### Step 4: Generate a New Token
+#### Step 4: Generate a New Token
 
 1. Click on the **Generate new token** button (you might be asked to enter you password again for security purposes).
 
-### Step 5: Configure & Generate the Token
+#### Step 5: Configure & Generate the Token
 
  - **Note**: Give your token a descriptive name so you can remember it's purpose
  - **Expiration**: Select the duration before the token expires (e.g., 30 days, 60 days, 90 days, custom, or no expiration).
  - **Select Scopes**: Scopes control access for the token. Choose what you need the token for (e.g., repo access, user data access). For typical repository operations, selecting `repo` is often sufficient.
 
     <img src=https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-github/master/docs/setup/resources/2-generate-token.png alt="Generate new PAT" width="50%">
+
+### Option 2: GitHub App with the OAuth2 refresh token grant
+
+#### Step 1: Register a GitHub App
+
+1. Go to **Settings** → **Developer settings** → **GitHub Apps** and click **New GitHub App**.
+2. Fill in the **GitHub App name**, **Homepage URL**, and the **Callback URL** that GitHub redirects to after a user authorizes the app.
+3. Under **Identifying and authorizing users**, make sure **Expire user authorization tokens** is enabled. GitHub only issues refresh tokens when this option is on; without it, user access tokens never expire and there is nothing to refresh.
+
+#### Step 2: Configure the app permissions
+
+Under **Permissions**, grant the repository, organization, and account permissions your integration needs. A GitHub App user access token is limited to these permissions — GitHub Apps ignore the OAuth `scope` parameter, so the `scopes` field of the connector configuration is not used for them.
+
+#### Step 3: Collect the client credentials
+
+On the app's settings page, note the **Client ID** and click **Generate a new client secret** to obtain the **Client secret**.
+
+#### Step 4: Install the app
+
+Click **Install App** and install it on the user account or organization whose resources you want to access.
+
+#### Step 5: Obtain a refresh token via the web application flow
+
+1. Direct the user to the authorization page, replacing the placeholders with your own values:
+
+    ```
+    https://github.com/login/oauth/authorize?client_id=<CLIENT_ID>&redirect_uri=<CALLBACK_URL>&state=<RANDOM_STRING>
+    ```
+
+2. After the user approves, GitHub redirects to the callback URL with a temporary `code` query parameter.
+
+3. Exchange that code for tokens:
+
+    ```bash
+    curl -X POST https://github.com/login/oauth/access_token \
+      -H "Accept: application/json" \
+      -d "client_id=<CLIENT_ID>" \
+      -d "client_secret=<CLIENT_SECRET>" \
+      -d "code=<CODE>" \
+      -d "redirect_uri=<CALLBACK_URL>"
+    ```
+
+    The response contains an `access_token` valid for 8 hours and a `refresh_token` valid for 6 months:
+
+    ```json
+    {
+      "access_token": "ghu_...",
+      "expires_in": 28800,
+      "refresh_token": "ghr_...",
+      "refresh_token_expires_in": 15811200,
+      "token_type": "bearer"
+    }
+    ```
+
+4. Keep the `client_id`, `client_secret`, and `refresh_token` — these are the three values the connector needs. The connector exchanges the refresh token for an access token on the first request and renews it automatically whenever it expires.
+
+> **Note:** GitHub rotates refresh tokens. Every renewal returns a new refresh token and invalidates the previous one. The connector holds the new token in memory for the lifetime of the `github:Client` value, but it is not written back to your configuration. If your process may be restarted after a token renewal, persist the latest refresh token yourself or re-run the authorization flow.
 
 ## Quickstart
 
@@ -55,7 +121,9 @@ import ballerinax/github;
 
 ### Step 2: Instantiate a new connector
 
-Create a `github:ConnectionConfig` with the obtained PAT and initialize the connector with it.
+Create a `github:ConnectionConfig` with the credentials obtained in the setup guide and initialize the connector with it.
+
+If you are authenticating with a **Personal Access Token**, provide the token directly:
 
 ```ballerina
 github:ConnectionConfig gitHubConfig = {
@@ -64,6 +132,33 @@ github:ConnectionConfig gitHubConfig = {
     }
 };
 github:Client github = check new (gitHubConfig);
+```
+
+If you are authenticating a **GitHub App with the OAuth2 refresh token grant**, provide the client credentials and the refresh token instead:
+
+```ballerina
+github:ConnectionConfig gitHubConfig = {
+    auth: {
+        clientId,
+        clientSecret,
+        refreshToken
+    }
+};
+github:Client github = check new (gitHubConfig);
+```
+
+The `refreshUrl` defaults to `https://github.com/login/oauth/access_token`, so it only needs to be set when you target a GitHub Enterprise Server instance:
+
+```ballerina
+github:ConnectionConfig gitHubConfig = {
+    auth: {
+        clientId,
+        clientSecret,
+        refreshToken,
+        refreshUrl: "https://github.example.com/login/oauth/access_token"
+    }
+};
+github:Client github = check new (gitHubConfig, "https://github.example.com/api/v3");
 ```
 
 ### Step 3: Invoke the connector operation

--- a/README.md
+++ b/README.md
@@ -40,11 +40,11 @@ The connector supports two ways of authenticating with the GitHub REST API:
 
 #### Step 4: Generate a New Token
 
-1. Click on the **Generate new token** button (you might be asked to enter you password again for security purposes).
+1. Click on the **Generate new token** button (you might be asked to enter your password again for security purposes).
 
 #### Step 5: Configure & Generate the Token
 
- - **Note**: Give your token a descriptive name so you can remember it's purpose
+ - **Note**: Give your token a descriptive name so you can remember its purpose
  - **Expiration**: Select the duration before the token expires (e.g., 30 days, 60 days, 90 days, custom, or no expiration).
  - **Select Scopes**: Scopes control access for the token. Choose what you need the token for (e.g., repo access, user data access). For typical repository operations, selecting `repo` is often sufficient.
 
@@ -72,13 +72,15 @@ Click **Install App** and install it on the user account or organization whose r
 
 #### Step 5: Obtain a refresh token via the web application flow
 
-1. Direct the user to the authorization page, replacing the placeholders with your own values:
+1. Direct the user to the authorization page, replacing the placeholders with your own values. Generate `<RANDOM_STRING>` fresh for every authorization attempt and store it against the user's session — it is the CSRF guard for this flow:
 
     ```
     https://github.com/login/oauth/authorize?client_id=<CLIENT_ID>&redirect_uri=<CALLBACK_URL>&state=<RANDOM_STRING>
     ```
 
-2. After the user approves, GitHub redirects to the callback URL with a temporary `code` query parameter.
+2. After the user approves, GitHub redirects to the callback URL with a temporary `code` query parameter and the `state` you sent.
+
+    Compare the returned `state` against the value you stored and **abort without exchanging the code** if it is absent or does not match. Skipping this check lets an attacker feed their own `code` to your callback and bind the victim's session to an account the attacker controls. Discard the stored value once used, so a `state` cannot be replayed.
 
 3. Exchange that code for tokens:
 
@@ -98,14 +100,14 @@ Click **Install App** and install it on the user account or organization whose r
       "access_token": "ghu_...",
       "expires_in": 28800,
       "refresh_token": "ghr_...",
-      "refresh_token_expires_in": 15811200,
+      "refresh_token_expires_in": 15897600,
       "token_type": "bearer"
     }
     ```
 
 4. Keep the `client_id`, `client_secret`, and `refresh_token` — these are the three values the connector needs. The connector exchanges the refresh token for an access token on the first request and renews it automatically whenever it expires.
 
-> **Note:** GitHub rotates refresh tokens. Every renewal returns a new refresh token and invalidates the previous one. The connector holds the new token in memory for the lifetime of the `github:Client` value, but it is not written back to your configuration. If your process may be restarted after a token renewal, persist the latest refresh token yourself or re-run the authorization flow.
+> **Note:** GitHub rotates refresh tokens. Every renewal returns a new refresh token and invalidates the previous one. The connector holds the new token in memory for the lifetime of the `github:Client` value; `ballerina/oauth2` provides no API to read it back, so it cannot be persisted. A process that restarts after a renewal therefore needs to be reauthorized with a freshly obtained refresh token.
 
 ## Quickstart
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ This Ballerina connector is designed to interface with [GitHub's REST API (versi
 
 ## Setup guide
 
-To use the GitHub Connector in Ballerina you need a GitHub account. If you already have one, you can integrate the connector with your existing account. If not, you can create a new GitHub account by visiting [GitHub's Sign Up page](https://github.com/) and following the registration process.
+To use the GitHub Connector in Ballerina, you need a GitHub account. If you already have one, you can integrate the connector with your existing account. If not, you can create a new GitHub account by visiting [GitHub's Sign Up page](https://github.com/) and following the registration process.
 
 The connector supports two ways of authenticating with the GitHub REST API:
 
@@ -40,13 +40,14 @@ The connector supports two ways of authenticating with the GitHub REST API:
 
 #### Step 4: Generate a New Token
 
-1. Click on the **Generate new token** button (you might be asked to enter your password again for security purposes).
+1. Click on the **Generate new token** button and choose either **classic** or **fine-grained**. The steps and screenshots below show a classic token; the fine-grained equivalent is noted in Step 5. You might be asked to enter your password again for security purposes.
 
 #### Step 5: Configure & Generate the Token
 
  - **Note**: Give your token a descriptive name so you can remember its purpose
  - **Expiration**: Select the duration before the token expires (e.g., 30 days, 60 days, 90 days, custom, or no expiration).
- - **Select Scopes**: Scopes control access for the token. Choose what you need the token for (e.g., repo access, user data access). For typical repository operations, selecting `repo` is often sufficient.
+ - **Select Scopes** *(classic tokens)*: Scopes control access for the token. Choose what you need the token for (e.g., repo access, user data access). For typical repository operations, selecting `repo` is often sufficient.
+ - **Select Permissions** *(fine-grained tokens)*: Fine-grained tokens have no scopes — `repo` and the other classic scopes do not appear. Instead, pick a **Resource owner**, limit **Repository access** to the repositories you need, and grant only the required **Repository permissions**. For the operations shown in the examples below, *Contents: Read and write* and *Issues: Read and write* are enough.
 
     <img src=https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-github/master/docs/setup/resources/2-generate-token.png alt="Generate new PAT" width="50%">
 
@@ -74,7 +75,7 @@ Click **Install App** and install it on the user account or organization whose r
 
 1. Direct the user to the authorization page, replacing the placeholders with your own values. Generate `<RANDOM_STRING>` fresh for every authorization attempt and store it against the user's session — it is the CSRF guard for this flow:
 
-    ```
+    ```text
     https://github.com/login/oauth/authorize?client_id=<CLIENT_ID>&redirect_uri=<CALLBACK_URL>&state=<RANDOM_STRING>
     ```
 

--- a/ballerina/Ballerina.toml
+++ b/ballerina/Ballerina.toml
@@ -2,7 +2,7 @@
 distribution = "2201.13.0"
 org = "ballerinax"
 name = "github"
-version = "6.0.0"
+version = "6.1.0"
 authors = ["Ballerina"]
 export = ["github"]
 keywords = ["Type/Connector", "Cost/Freemium", "Vendor/GitHub", "Area/Developer Tools", "IT Operations/Source Control"]

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.4"
+distribution-version = "2201.13.0"
 
 [[package]]
 org = "ballerina"

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -333,7 +333,7 @@ dependencies = [
 [[package]]
 org = "ballerinax"
 name = "github"
-version = "6.0.0"
+version = "6.1.0"
 dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},

--- a/ballerina/Dependencies.toml
+++ b/ballerina/Dependencies.toml
@@ -5,7 +5,7 @@
 
 [ballerina]
 dependencies-toml-version = "2"
-distribution-version = "2201.13.0"
+distribution-version = "2201.13.4"
 
 [[package]]
 org = "ballerina"
@@ -53,7 +53,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "data.jsondata"
-version = "1.1.3"
+version = "1.1.4"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.object"}
@@ -76,7 +76,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "http"
-version = "2.15.5"
+version = "2.15.7"
 dependencies = [
 	{org = "ballerina", name = "auth"},
 	{org = "ballerina", name = "cache"},
@@ -109,7 +109,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "io"
-version = "1.8.0"
+version = "1.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "lang.value"}
@@ -232,7 +232,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "mime"
-version = "2.12.1"
+version = "2.12.2"
 dependencies = [
 	{org = "ballerina", name = "io"},
 	{org = "ballerina", name = "jballerina.java"},
@@ -251,6 +251,9 @@ dependencies = [
 	{org = "ballerina", name = "log"},
 	{org = "ballerina", name = "time"},
 	{org = "ballerina", name = "url"}
+]
+modules = [
+	{org = "ballerina", packageName = "oauth2", moduleName = "oauth2"}
 ]
 
 [[package]]
@@ -276,7 +279,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "task"
-version = "2.11.1"
+version = "2.11.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"},
 	{org = "ballerina", name = "time"},
@@ -300,7 +303,7 @@ modules = [
 [[package]]
 org = "ballerina"
 name = "time"
-version = "2.8.0"
+version = "2.8.1"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -308,7 +311,7 @@ dependencies = [
 [[package]]
 org = "ballerina"
 name = "url"
-version = "2.6.1"
+version = "2.6.2"
 dependencies = [
 	{org = "ballerina", name = "jballerina.java"}
 ]
@@ -335,6 +338,7 @@ dependencies = [
 	{org = "ballerina", name = "constraint"},
 	{org = "ballerina", name = "data.jsondata"},
 	{org = "ballerina", name = "http"},
+	{org = "ballerina", name = "oauth2"},
 	{org = "ballerina", name = "os"},
 	{org = "ballerina", name = "test"},
 	{org = "ballerina", name = "url"}

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -9,39 +9,105 @@ The GitHub connector is designed to interface with [GitHub's REST API (version 2
 - Manage repositories, branches, and collaborators programmatically
 - Create, update, and track issues and pull requests
 - Automate workflows with GitHub's REST API
-- Support for Personal Access Token (PAT) authentication
+- Support for Personal Access Token (PAT) and OAuth2 refresh token grant authentication
 
 ## Setup guide
 
-To use the GitHub Connector, you must have a GitHub account and a Personal Access Token (PAT) for authentication. If you already have a GitHub account, you can integrate the connector with your existing account. If not, you can create a new GitHub account by visiting [GitHub's Sign Up page](https://github.com/) and following the registration process. Once you have a GitHub account, you can proceed to create a PAT.
+To use the GitHub connector you need a GitHub account. If you already have one, you can integrate the connector with your existing account. If not, create a new account by visiting [GitHub's Sign Up page](https://github.com/) and following the registration process.
 
-### Step 1: Access GitHub Settings
+The connector supports two ways of authenticating with the GitHub REST API:
+
+| Authentication | When to use |
+| -------------- | ----------- |
+| **Personal Access Token (PAT)** | A static token bound to your own user account. Simplest option, suited for scripts and single-user automation. Also use this for an OAuth App token, which does not expire. |
+| **OAuth2 refresh token grant** | A GitHub App user access token, which expires after 8 hours and is renewed automatically by the connector. Suited for applications acting on behalf of other users. Requires a GitHub App with expiring user authorization tokens enabled — OAuth Apps do not issue refresh tokens. |
+
+### Option 1: Personal Access Token (PAT)
+
+#### Step 1: Access GitHub Settings
 
 1. Once logged in, click on the profile picture in the top-right corner of the page.
 2. Select **Settings** from the dropdown menu.
 
-### Step 2: Navigate to Developer Settings
+#### Step 2: Navigate to Developer Settings
 
 1. Scroll down in the sidebar on the left side of the settings page.
 2. click on **Developer settings** located near the bottom.
 
-### Step 3: Go to Personal Access Tokens
+#### Step 3: Go to Personal Access Tokens
 
 1. Inside Developer Settings find and click on **Personal access tokens**.
 
     <img src=https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-github/master/docs/setup/resources/1-developer-settings.png alt="GitHub Developer Settings">
 
-### Step 4: Generate a New Token
+#### Step 4: Generate a New Token
 
 1. Click on the **Generate new token** button (you might be asked to enter you password again for security purposes).
 
-### Step 5: Configure & Generate the Token
+#### Step 5: Configure & Generate the Token
 
  - **Note**: Give your token a descriptive name so you can remember it's purpose
  - **Expiration**: Select the duration before the token expires (e.g., 30 days, 60 days, 90 days, custom, or no expiration).
  - **Select Scopes**: Scopes control access for the token. Choose what you need the token for (e.g., repo access, user data access). For typical repository operations, selecting `repo` is often sufficient.
 
     <img src=https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-github/master/docs/setup/resources/2-generate-token.png alt="Generate new PAT">
+
+### Option 2: GitHub App with the OAuth2 refresh token grant
+
+#### Step 1: Register a GitHub App
+
+1. Go to **Settings** → **Developer settings** → **GitHub Apps** and click **New GitHub App**.
+2. Fill in the **GitHub App name**, **Homepage URL**, and the **Callback URL** that GitHub redirects to after a user authorizes the app.
+3. Under **Identifying and authorizing users**, make sure **Expire user authorization tokens** is enabled. GitHub only issues refresh tokens when this option is on; without it, user access tokens never expire and there is nothing to refresh.
+
+#### Step 2: Configure the app permissions
+
+Under **Permissions**, grant the repository, organization, and account permissions your integration needs. A GitHub App user access token is limited to these permissions — GitHub Apps ignore the OAuth `scope` parameter, so the `scopes` field of the connector configuration is not used for them.
+
+#### Step 3: Collect the client credentials
+
+On the app's settings page, note the **Client ID** and click **Generate a new client secret** to obtain the **Client secret**.
+
+#### Step 4: Install the app
+
+Click **Install App** and install it on the user account or organization whose resources you want to access.
+
+#### Step 5: Obtain a refresh token via the web application flow
+
+1. Direct the user to the authorization page, replacing the placeholders with your own values:
+
+    ```
+    https://github.com/login/oauth/authorize?client_id=<CLIENT_ID>&redirect_uri=<CALLBACK_URL>&state=<RANDOM_STRING>
+    ```
+
+2. After the user approves, GitHub redirects to the callback URL with a temporary `code` query parameter.
+
+3. Exchange that code for tokens:
+
+    ```bash
+    curl -X POST https://github.com/login/oauth/access_token \
+      -H "Accept: application/json" \
+      -d "client_id=<CLIENT_ID>" \
+      -d "client_secret=<CLIENT_SECRET>" \
+      -d "code=<CODE>" \
+      -d "redirect_uri=<CALLBACK_URL>"
+    ```
+
+    The response contains an `access_token` valid for 8 hours and a `refresh_token` valid for 6 months:
+
+    ```json
+    {
+      "access_token": "ghu_...",
+      "expires_in": 28800,
+      "refresh_token": "ghr_...",
+      "refresh_token_expires_in": 15811200,
+      "token_type": "bearer"
+    }
+    ```
+
+4. Keep the `client_id`, `client_secret`, and `refresh_token` — these are the three values the connector needs. The connector exchanges the refresh token for an access token on the first request and renews it automatically whenever it expires.
+
+> **Note:** GitHub rotates refresh tokens. Every renewal returns a new refresh token and invalidates the previous one. The connector holds the new token in memory for the lifetime of the `github:Client` value, but it is not written back to your configuration. If your process may be restarted after a token renewal, persist the latest refresh token yourself or re-run the authorization flow.
 
 ## Quickstart
 
@@ -57,7 +123,9 @@ import ballerinax/github;
 
 ### Step 2: Instantiate a new connector
 
-Create a `github:ConnectionConfig` with the obtained PAT and initialize the connector with it.
+Create a `github:ConnectionConfig` with the credentials obtained in the setup guide and initialize the connector with it.
+
+If you are authenticating with a **Personal Access Token**, provide the token directly:
 
 ```ballerina
 github:ConnectionConfig gitHubConfig = {
@@ -66,6 +134,33 @@ github:ConnectionConfig gitHubConfig = {
     }
 };
 github:Client github = check new (gitHubConfig);
+```
+
+If you are authenticating a **GitHub App with the OAuth2 refresh token grant**, provide the client credentials and the refresh token instead:
+
+```ballerina
+github:ConnectionConfig gitHubConfig = {
+    auth: {
+        clientId,
+        clientSecret,
+        refreshToken
+    }
+};
+github:Client github = check new (gitHubConfig);
+```
+
+The `refreshUrl` defaults to `https://github.com/login/oauth/access_token`, so it only needs to be set when you target a GitHub Enterprise Server instance:
+
+```ballerina
+github:ConnectionConfig gitHubConfig = {
+    auth: {
+        clientId,
+        clientSecret,
+        refreshToken,
+        refreshUrl: "https://github.example.com/login/oauth/access_token"
+    }
+};
+github:Client github = check new (gitHubConfig, "https://github.example.com/api/v3");
 ```
 
 ### Step 3: Invoke the connector operation

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -13,7 +13,7 @@ The GitHub connector is designed to interface with [GitHub's REST API (version 2
 
 ## Setup guide
 
-To use the GitHub connector you need a GitHub account. If you already have one, you can integrate the connector with your existing account. If not, create a new account by visiting [GitHub's Sign Up page](https://github.com/) and following the registration process.
+To use the GitHub connector, you need a GitHub account. If you already have one, you can integrate the connector with your existing account. If not, create a new account by visiting [GitHub's Sign Up page](https://github.com/) and following the registration process.
 
 The connector supports two ways of authenticating with the GitHub REST API:
 
@@ -42,13 +42,14 @@ The connector supports two ways of authenticating with the GitHub REST API:
 
 #### Step 4: Generate a New Token
 
-1. Click on the **Generate new token** button (you might be asked to enter your password again for security purposes).
+1. Click on the **Generate new token** button and choose either **classic** or **fine-grained**. The steps and screenshots below show a classic token; the fine-grained equivalent is noted in Step 5. You might be asked to enter your password again for security purposes.
 
 #### Step 5: Configure & Generate the Token
 
  - **Note**: Give your token a descriptive name so you can remember its purpose
  - **Expiration**: Select the duration before the token expires (e.g., 30 days, 60 days, 90 days, custom, or no expiration).
- - **Select Scopes**: Scopes control access for the token. Choose what you need the token for (e.g., repo access, user data access). For typical repository operations, selecting `repo` is often sufficient.
+ - **Select Scopes** *(classic tokens)*: Scopes control access for the token. Choose what you need the token for (e.g., repo access, user data access). For typical repository operations, selecting `repo` is often sufficient.
+ - **Select Permissions** *(fine-grained tokens)*: Fine-grained tokens have no scopes — `repo` and the other classic scopes do not appear. Instead, pick a **Resource owner**, limit **Repository access** to the repositories you need, and grant only the required **Repository permissions**. For the operations shown in the examples below, *Contents: Read and write* and *Issues: Read and write* are enough.
 
     <img src=https://raw.githubusercontent.com/ballerina-platform/module-ballerinax-github/master/docs/setup/resources/2-generate-token.png alt="Generate new PAT">
 
@@ -76,7 +77,7 @@ Click **Install App** and install it on the user account or organization whose r
 
 1. Direct the user to the authorization page, replacing the placeholders with your own values. Generate `<RANDOM_STRING>` fresh for every authorization attempt and store it against the user's session — it is the CSRF guard for this flow:
 
-    ```
+    ```text
     https://github.com/login/oauth/authorize?client_id=<CLIENT_ID>&redirect_uri=<CALLBACK_URL>&state=<RANDOM_STRING>
     ```
 

--- a/ballerina/README.md
+++ b/ballerina/README.md
@@ -42,11 +42,11 @@ The connector supports two ways of authenticating with the GitHub REST API:
 
 #### Step 4: Generate a New Token
 
-1. Click on the **Generate new token** button (you might be asked to enter you password again for security purposes).
+1. Click on the **Generate new token** button (you might be asked to enter your password again for security purposes).
 
 #### Step 5: Configure & Generate the Token
 
- - **Note**: Give your token a descriptive name so you can remember it's purpose
+ - **Note**: Give your token a descriptive name so you can remember its purpose
  - **Expiration**: Select the duration before the token expires (e.g., 30 days, 60 days, 90 days, custom, or no expiration).
  - **Select Scopes**: Scopes control access for the token. Choose what you need the token for (e.g., repo access, user data access). For typical repository operations, selecting `repo` is often sufficient.
 
@@ -74,13 +74,15 @@ Click **Install App** and install it on the user account or organization whose r
 
 #### Step 5: Obtain a refresh token via the web application flow
 
-1. Direct the user to the authorization page, replacing the placeholders with your own values:
+1. Direct the user to the authorization page, replacing the placeholders with your own values. Generate `<RANDOM_STRING>` fresh for every authorization attempt and store it against the user's session — it is the CSRF guard for this flow:
 
     ```
     https://github.com/login/oauth/authorize?client_id=<CLIENT_ID>&redirect_uri=<CALLBACK_URL>&state=<RANDOM_STRING>
     ```
 
-2. After the user approves, GitHub redirects to the callback URL with a temporary `code` query parameter.
+2. After the user approves, GitHub redirects to the callback URL with a temporary `code` query parameter and the `state` you sent.
+
+    Compare the returned `state` against the value you stored and **abort without exchanging the code** if it is absent or does not match. Skipping this check lets an attacker feed their own `code` to your callback and bind the victim's session to an account the attacker controls. Discard the stored value once used, so a `state` cannot be replayed.
 
 3. Exchange that code for tokens:
 
@@ -100,14 +102,14 @@ Click **Install App** and install it on the user account or organization whose r
       "access_token": "ghu_...",
       "expires_in": 28800,
       "refresh_token": "ghr_...",
-      "refresh_token_expires_in": 15811200,
+      "refresh_token_expires_in": 15897600,
       "token_type": "bearer"
     }
     ```
 
 4. Keep the `client_id`, `client_secret`, and `refresh_token` — these are the three values the connector needs. The connector exchanges the refresh token for an access token on the first request and renews it automatically whenever it expires.
 
-> **Note:** GitHub rotates refresh tokens. Every renewal returns a new refresh token and invalidates the previous one. The connector holds the new token in memory for the lifetime of the `github:Client` value, but it is not written back to your configuration. If your process may be restarted after a token renewal, persist the latest refresh token yourself or re-run the authorization flow.
+> **Note:** GitHub rotates refresh tokens. Every renewal returns a new refresh token and invalidates the previous one. The connector holds the new token in memory for the lifetime of the `github:Client` value; `ballerina/oauth2` provides no API to read it back, so it cannot be persisted. A process that restarts after a renewal therefore needs to be reauthorized with a freshly obtained refresh token.
 
 ## Quickstart
 

--- a/ballerina/types.bal
+++ b/ballerina/types.bal
@@ -17,6 +17,7 @@
 import ballerina/constraint;
 import ballerina/data.jsondata;
 import ballerina/http;
+import ballerina/oauth2;
 
 public type ReposownerrepobranchesbranchprotectionrestrictionsappsreposownerrepobranchesbranchprotectionrestrictionsappsOneOf12 string[];
 
@@ -17123,11 +17124,22 @@ public type TeamsListForAuthenticatedUserQueries record {
     int page = 1;
 };
 
+# OAuth2 Refresh Token Grant Configs
+public type OAuth2RefreshTokenGrantConfig record {|
+    *http:OAuth2RefreshTokenGrantConfig;
+    # Refresh URL
+    string refreshUrl = "https://github.com/login/oauth/access_token";
+    # GitHub expects `client_id` and `client_secret` in the request body, not in a Basic auth header
+    oauth2:CredentialBearer credentialBearer = oauth2:POST_BODY_BEARER;
+    # Sends `Accept: application/json`; without it GitHub returns a form-encoded token response
+    oauth2:ClientConfiguration clientConfig = {customHeaders: {"Accept": "application/json"}};
+|};
+
 # Provides a set of configurations for controlling the behaviours when communicating with a remote HTTP endpoint.
 @display {label: "Connection Config"}
 public type ConnectionConfig record {|
     # Configurations related to client authentication
-    http:BearerTokenConfig auth;
+    http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig auth;
     # The HTTP version understood by the client
     http:HttpVersion httpVersion = http:HTTP_2_0;
     # Configurations related to HTTP/1.x protocol

--- a/changelog.md
+++ b/changelog.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
-- Added support for the OAuth2 refresh token grant, so GitHub App user access tokens are renewed automatically when they expire. `ConnectionConfig.auth` now accepts `http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig`; existing PAT configurations are unaffected
+- [[#9014](https://github.com/ballerina-platform/ballerina-library/issues/9014)] Added support for the OAuth2 refresh token grant, so GitHub App user access tokens are renewed automatically when they expire. `ConnectionConfig.auth` now accepts `http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig`; existing PAT configurations are unaffected
 
 ## [6.0.0] - 2026-05-14
 

--- a/changelog.md
+++ b/changelog.md
@@ -9,6 +9,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - Added support for the OAuth2 refresh token grant, so GitHub App user access tokens are renewed automatically when they expire. `ConnectionConfig.auth` now accepts `http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig`; existing PAT configurations are unaffected
 
+## [6.0.0] - 2026-05-14
+
 ### Breaking Changes
 - [[#8642](https://github.com/ballerina-platform/ballerina-library/issues/8642)] Regenerated the connector from the aligned OpenAPI specification
   - Record field names now use camelCase with `@jsondata:Name` annotations for JSON mapping (e.g., `created_at` -> `createdAt`, `body_html` -> `bodyHtml`)

--- a/changelog.md
+++ b/changelog.md
@@ -6,6 +6,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+- Added support for the OAuth2 refresh token grant, so GitHub App user access tokens are renewed automatically when they expire. `ConnectionConfig.auth` now accepts `http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig`; existing PAT configurations are unaffected
+
 ### Breaking Changes
 - [[#8642](https://github.com/ballerina-platform/ballerina-library/issues/8642)] Regenerated the connector from the aligned OpenAPI specification
   - Record field names now use camelCase with `@jsondata:Name` annotations for JSON mapping (e.g., `created_at` -> `createdAt`, `body_html` -> `bodyHtml`)

--- a/docs/spec/Sanitations.md
+++ b/docs/spec/Sanitations.md
@@ -100,7 +100,9 @@ This file documents the modifications applied to enhance the usability of the of
     }
     ```
 
-    Only the `authorizationCode` flow is declared, because it is the only OAuth2 grant GitHub implements. GitHub does not support the client credentials, resource owner password, or JWT bearer grants, so no other `flows` entry would be honoured by the token endpoint.
+    Only the `authorizationCode` flow is declared, because this connector models just GitHub's **web application flow** — the one that issues the user access token and refresh token pair the generated client then renews. Of the four flow types an OpenAPI 3.0 OAuth Flows Object permits (`implicit`, `password`, `clientCredentials`, `authorizationCode`), it is also the only one GitHub's token endpoint would honour.
+
+    This is not a claim that GitHub implements no other OAuth2 grant. GitHub also offers the **device flow**, which is out of scope here rather than unsupported by GitHub.
 
     The scheme deliberately covers **only** GitHub App user access tokens with expiry enabled. OAuth App tokens and personal access tokens neither expire nor carry a refresh token, so they remain on the pre-existing `bearerAuth` scheme; the description states this so the empty `scopes` map cannot be read as an omission.
 
@@ -110,7 +112,7 @@ This file documents the modifications applied to enhance the usability of the of
 
     GitHub's published specification will never carry this scheme, so both additions must be re-applied whenever the spec is refreshed from upstream.
 
-16. Override two defaults on the generated `OAuth2RefreshTokenGrantConfig` record in `ballerina/types.bal` so the refresh token grant works against GitHub out of the box. This is a **post-generation edit** — regenerating the client drops both overrides, so they must be re-applied.
+16. Add the defaults to the generated `OAuth2RefreshTokenGrantConfig` record in `ballerina/types.bal` so the refresh token grant works against GitHub out of the box. They are **post-generation edits** — regenerating the client drops them, so they must be re-applied.
 
     ```ballerina
     # OAuth2 Refresh Token Grant Configs
@@ -118,9 +120,11 @@ This file documents the modifications applied to enhance the usability of the of
         *http:OAuth2RefreshTokenGrantConfig;
         # Refresh URL
         string refreshUrl = "https://github.com/login/oauth/access_token";
-        # ...
+
+        // added by hand — re-apply both after every regeneration
+        # GitHub expects `client_id` and `client_secret` in the request body, not in a Basic auth header
         oauth2:CredentialBearer credentialBearer = oauth2:POST_BODY_BEARER;
-        # ...
+        # Sends `Accept: application/json`; without it GitHub returns a form-encoded token response
         oauth2:ClientConfiguration clientConfig = {customHeaders: {"Accept": "application/json"}};
     |};
     ```

--- a/docs/spec/Sanitations.md
+++ b/docs/spec/Sanitations.md
@@ -76,6 +76,60 @@ This file documents the modifications applied to enhance the usability of the of
 
 14. Remove the `default: false` from the `allow_forking` field in the `PATCH /repos/{owner}/{repo}` request body (`OwnerrepoBody1`). The GitHub API returns a 422 ("Allow forks can only be changed on org-owned repositories") if `allow_forking` is sent for a personal repository, but the default caused it to always be included in the request. Making it optional (no default) resolves this.
 
+15. Add an `oauth2` security scheme so the connector supports the OAuth2 refresh token grant in addition to the Personal Access Token. The source spec declared only `bearerAuth` (`type: http`, `scheme: bearer`) and had no root-level `security` requirement, so the generated `ConnectionConfig.auth` was limited to `http:BearerTokenConfig` — GitHub App user access tokens, which expire after 8 hours, could not be renewed by the connector. Two additions were made under `components.securitySchemes` and at the root:
+
+    ```jsonc
+    "security": [
+      { "bearerAuth": [] },
+      { "oauth2": [] }
+    ]
+    ```
+
+    ```jsonc
+    "oauth2": {
+      "type": "oauth2",
+      "description": "...",
+      "flows": {
+        "authorizationCode": {
+          "authorizationUrl": "https://github.com/login/oauth/authorize",
+          "tokenUrl": "https://github.com/login/oauth/access_token",
+          "refreshUrl": "https://github.com/login/oauth/access_token",
+          "scopes": {}
+        }
+      }
+    }
+    ```
+
+    Only the `authorizationCode` flow is declared, because it is the only OAuth2 grant GitHub implements. GitHub does not support the client credentials, resource owner password, or JWT bearer grants, so no other `flows` entry would be honoured by the token endpoint.
+
+    The scheme deliberately covers **only** GitHub App user access tokens with expiry enabled. OAuth App tokens and personal access tokens neither expire nor carry a refresh token, so they remain on the pre-existing `bearerAuth` scheme; the description states this so the empty `scopes` map cannot be read as an omission.
+
+    `scopes` is left empty. The OpenAPI 3.0 OAuth Flow Object requires the key but permits an empty map, and populating it would be misleading here: the only grant this scheme supports is the refresh token grant, which is available only to GitHub Apps, and GitHub Apps ignore the `scope` parameter entirely. The value is also inert for code generation — `bal openapi` keys off the presence of the flow and its `tokenUrl`, never the scope list.
+
+    Because the flow declares a `tokenUrl`, `bal openapi` widens the generated `ConnectionConfig.auth` to `http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig` and emits an `OAuth2RefreshTokenGrantConfig` record that includes `*http:OAuth2RefreshTokenGrantConfig` with `refreshUrl` defaulted to the flow's `tokenUrl`. The PAT configuration (`auth: {token: ...}`) is unchanged and still resolves to `http:BearerTokenConfig`, so this is a backward-compatible change.
+
+    GitHub's published specification will never carry this scheme, so both additions must be re-applied whenever the spec is refreshed from upstream.
+
+16. Override two defaults on the generated `OAuth2RefreshTokenGrantConfig` record in `ballerina/types.bal` so the refresh token grant works against GitHub out of the box. This is a **post-generation edit** — regenerating the client drops both overrides, so they must be re-applied.
+
+    ```ballerina
+    # OAuth2 Refresh Token Grant Configs
+    public type OAuth2RefreshTokenGrantConfig record {|
+        *http:OAuth2RefreshTokenGrantConfig;
+        # Refresh URL
+        string refreshUrl = "https://github.com/login/oauth/access_token";
+        # ...
+        oauth2:CredentialBearer credentialBearer = oauth2:POST_BODY_BEARER;
+        # ...
+        oauth2:ClientConfiguration clientConfig = {customHeaders: {"Accept": "application/json"}};
+    |};
+    ```
+
+    - `clientConfig` — `https://github.com/login/oauth/access_token` responds with an `application/x-www-form-urlencoded` body (`access_token=...&token_type=bearer`) unless the request carries `Accept: application/json`. `ballerina/oauth2` sets only `Content-Type` on the token request and then parses the response with `fromJsonString()`, so without this header every refresh fails with "Failed to get JSON from the response payload." The header is injected through `oauth2:ClientConfiguration.customHeaders`, which requires the added `import ballerina/oauth2;` in `types.bal`.
+    - `credentialBearer` — `ballerina/oauth2` defaults to `AUTH_HEADER_BEARER`, which sends the client credentials as an `Authorization: Basic` header. GitHub documents `client_id` and `client_secret` as request body parameters for this endpoint and does not document Basic client authentication, so the default is changed to `POST_BODY_BEARER` to match the documented request shape.
+
+    Note that GitHub rotates refresh tokens: each renewal returns a new refresh token and invalidates the previous one. `ballerina/oauth2` caches the rotated token in its in-memory `TokenCache` (`extractRefreshToken` → `tokenCache.update`) but exposes no hook to persist it, so a restarted process must supply a freshly obtained refresh token. This is documented in the README rather than worked around in the connector.
+
 ## OpenAPI cli command
 
 **Important:** The overlay must be applied AFTER `bal openapi align`, not before. The align

--- a/docs/spec/openapi.json
+++ b/docs/spec/openapi.json
@@ -24,6 +24,14 @@
       "url": "https://api.github.com"
     }
   ],
+  "security": [
+    {
+      "bearerAuth": []
+    },
+    {
+      "oauth2": []
+    }
+  ],
   "tags": [
     {
       "name": "actions",
@@ -133884,6 +133892,18 @@
         "type": "http",
         "scheme": "bearer",
         "bearerFormat": "JWT"
+      },
+      "oauth2": {
+        "type": "oauth2",
+        "description": "OAuth 2.0 authorization for GitHub Apps that have expiring user access tokens enabled. The web application (authorization code) flow issues a user-to-server access token that is sent as `Authorization: Bearer <token>`; it is valid for 8 hours and is renewed against the same token endpoint with `grant_type=refresh_token` using the refresh token issued alongside it (valid for 6 months). GitHub rotates the refresh token on every renewal. `scopes` is empty because GitHub Apps ignore the `scope` parameter and derive access from the permissions granted to the app installation. This scheme does not cover OAuth App tokens or personal access tokens: neither expires nor carries a refresh token, so both authenticate through the `bearerAuth` scheme instead. Note that the token endpoint returns an `application/x-www-form-urlencoded` body unless the request carries an `Accept: application/json` header.",
+        "flows": {
+          "authorizationCode": {
+            "authorizationUrl": "https://github.com/login/oauth/authorize",
+            "tokenUrl": "https://github.com/login/oauth/access_token",
+            "refreshUrl": "https://github.com/login/oauth/access_token",
+            "scopes": {}
+          }
+        }
       }
     }
   }

--- a/gradle.properties
+++ b/gradle.properties
@@ -1,6 +1,6 @@
 org.gradle.caching=true
 group=io.ballerina.stdlib
-version=6.0.1-SNAPSHOT
+version=6.1.0-SNAPSHOT
 
 ballerinaLangVersion=2201.13.0
 releasePluginVersion=2.8.0


### PR DESCRIPTION
# Description

Adds OAuth2 refresh token grant support to the GitHub connector, alongside the
existing Personal Access Token authentication.

`ConnectionConfig.auth` is widened from `http:BearerTokenConfig` to
`http:BearerTokenConfig|OAuth2RefreshTokenGrantConfig`

- **GitHub Apps** — user access tokens expire after 8 hours. The connector now
  renews them automatically via `ballerina/oauth2` using the client credentials
  and refresh token. Previously there was no way to use a GitHub App at all.
- **PAT** — unchanged. `auth: {token: ...}` still resolves to
  `http:BearerTokenConfig`, so this is non-breaking.
- **OAuth Apps** — their tokens do not expire and carry no refresh token, so they
  continue to use the same bearer path as a PAT.
  
  Issue - https://github.com/ballerina-platform/ballerina-library/issues/9014

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
- Added OAuth2 refresh token grant support for GitHub App user access tokens.
- Updated `ConnectionConfig.auth` to support PAT and `OAuth2RefreshTokenGrantConfig` authentication.
- Added GitHub-specific OAuth2 configuration defaults through `ballerina/oauth2`.
- Updated README files and OpenAPI specifications with setup and usage guidance.
- Updated dependencies, changelog entries, and project versions for 6.1.0.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->